### PR TITLE
Use dated tag for base image to make sure image is updated

### DIFF
--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_base.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_base.Dockerfile
@@ -2,7 +2,7 @@
 # It needs to be built from the root of the intrinsic_sdk_ros repository.
 
 # base stage: ghcr.io/sloretz/ros:jazzy-ros-core + configs + rmw_zenoh
-FROM ghcr.io/sloretz/ros:jazzy-ros-core AS base
+FROM ghcr.io/sloretz/ros:jazzy-ros-core-2025-06-08 AS base
 # TODO(wjwwood): this is based on the ROS image because we still use
 #   ament_cmake, we should move away from that and either vendor ament_cmake or
 #   avoid it entirely.


### PR DESCRIPTION
This switches the base image to use a dated tag. The problem with a non-dated one is docker and podman only pull new images when they don't exist locally. If `ghcr.io/sloretz/ros:jazzy-ros-core` exists, then whatever version it is is used.

I looked briefly at dependabot's configuration to see if it would bump this version automatically for us, but I'm not sure if it would or not.