### PR TITLE
Add missing ament cmake vendor package

### DIFF
--- a/resources/Dockerfile.service
+++ b/resources/Dockerfile.service
@@ -19,7 +19,7 @@ ADD src/intrinsic_sdk_ros /opt/ros/underlay/src/intrinsic_sdk_ros
 
 RUN . /opt/ros/jazzy/setup.sh \
     && apt-get update \
-    && apt install -y \
+    && apt install -y ros-jazzy-ament-cmake-vendor-package \
     && colcon build \
         --continue-on-error \
         --event-handlers=console_direct+ \


### PR DESCRIPTION
The refactor in https://github.com/intrinsic-ai/sdk-ros/pull/19 removed the ament-cmake-vendor package which made the docker builds fail:

```
8.034 CMake Error at CMakeLists.txt:11 (find_package):
8.034   By not providing "Findament_cmake_vendor_package.cmake" in
8.034   CMAKE_MODULE_PATH this project has asked CMake to find a package
8.034   configuration file provided by "ament_cmake_vendor_package", but CMake did
8.034   not find one.
8.035 
8.035   Could not find a package configuration file provided by
8.035   "ament_cmake_vendor_package" with any of the following names:
8.035 
8.035     ament_cmake_vendor_packageConfig.cmake
8.035     ament_cmake_vendor_package-config.cmake
8.036 
8.036   Add the installation prefix of "ament_cmake_vendor_package" to
8.036   CMAKE_PREFIX_PATH or set "ament_cmake_vendor_package_DIR" to a directory
8.036   containing one of the above files.  If "ament_cmake_vendor_package"
8.036   provides a separate development package or SDK, be sure it has been
8.036   installed.
8.037 
8.037 
8.037 -- Configuring incomplete, errors occurred!
8.037 CMake Error at CMakeLists.txt:11 (find_package):
8.037   By not providing "Findament_cmake_vendor_package.cmake" in
8.037   CMAKE_MODULE_PATH this project has asked CMake to find a package
8.038   configuration file provided by "ament_cmake_vendor_package", but CMake did
8.039   not find one.
8.039 
8.040   Could not find a package configuration file provided by
8.040   "ament_cmake_vendor_package" with any of the following names:
8.041 
8.041     ament_cmake_vendor_packageConfig.cmake
8.041     ament_cmake_vendor_package-config.cmake
8.041 
8.041   Add the installation prefix of "ament_cmake_vendor_package" to
8.042   CMAKE_PREFIX_PATH or set "ament_cmake_vendor_package_DIR" to a directory
8.042   containing one of the above files.  If "ament_cmake_vendor_package"
8.042   provides a separate development package or SDK, be sure it has been
8.043   installed.
8.043 
8.044 
8.045 CMake Error at CMakeLists.txt:11 (find_package):
8.045   By not providing "Findament_cmake_vendor_package.cmake" in
8.045   CMAKE_MODULE_PATH this project has asked CMake to find a package
8.045   configuration file provided by "ament_cmake_vendor_package", but CMake did
8.045   not find one.
8.046 
8.046   Could not find a package configuration file provided by
8.047   "ament_cmake_vendor_package" with any of the following names:
8.047 
8.047     ament_cmake_vendor_packageConfig.cmake
8.047     ament_cmake_vendor_package-config.cmake
8.047 
8.048   Add the installation prefix of "ament_cmake_vendor_package" to
8.048   CMAKE_PREFIX_PATH or set "ament_cmake_vendor_package_DIR" to a directory
8.048   containing one of the above files.  If "ament_cmake_vendor_package"
8.049   provides a separate development package or SDK, be sure it has been
8.049   installed.
8.049 
8.050 
8.050 -- Configuring incomplete, errors occurred!
8.050 -- Configuring incomplete, errors occurred!
8.050 CMake Error at CMakeLists.txt:11 (find_package):
8.050   By not providing "Findament_cmake_vendor_package.cmake" in
8.051   CMAKE_MODULE_PATH this project has asked CMake to find a package
8.052   configuration file provided by "ament_cmake_vendor_package", but CMake did
8.052   not find one.
8.052 
8.052   Could not find a package configuration file provided by
8.052   "ament_cmake_vendor_package" with any of the following names:
8.052 
8.053     ament_cmake_vendor_packageConfig.cmake
8.053     ament_cmake_vendor_package-config.cmake
8.053 
8.053   Add the installation prefix of "ament_cmake_vendor_package" to
8.053   CMAKE_PREFIX_PATH or set "ament_cmake_vendor_package_DIR" to a directory
8.053   containing one of the above files.  If "ament_cmake_vendor_package"
8.053   provides a separate development package or SDK, be sure it has been
8.054   installed.
8.054 
8.054 
8.054 -- Configuring incomplete, errors occurred!
8.076 --- stderr: abseil_cpp_vendor
8.076 CMake Error at CMakeLists.txt:11 (find_package):
8.076   By not providing "Findament_cmake_vendor_package.cmake" in
8.076   CMAKE_MODULE_PATH this project has asked CMake to find a package
8.076   configuration file provided by "ament_cmake_vendor_package", but CMake did
8.076   not find one.
8.076 
8.076   Could not find a package configuration file provided by
8.076   "ament_cmake_vendor_package" with any of the following names:
8.076 
8.076     ament_cmake_vendor_packageConfig.cmake
8.076     ament_cmake_vendor_package-config.cmake
8.076 
8.076   Add the installation prefix of "ament_cmake_vendor_package" to
8.076   CMAKE_PREFIX_PATH or set "ament_cmake_vendor_package_DIR" to a directory
8.076   containing one of the above files.  If "ament_cmake_vendor_package"
8.076   provides a separate development package or SDK, be sure it has been
8.076   installed.
8.076 
8.076 
8.076 ---
8.076 Failed   <<< abseil_cpp_vendor [0.91s, exited with code 1]
8.083 --- stderr: intrinsic_pybind11_vendor
8.083 CMake Error at CMakeLists.txt:11 (find_package):
8.083   By not providing "Findament_cmake_vendor_package.cmake" in
8.083   CMAKE_MODULE_PATH this project has asked CMake to find a package
8.083   configuration file provided by "ament_cmake_vendor_package", but CMake did
8.083   not find one.
8.083 
8.083   Could not find a package configuration file provided by
8.083   "ament_cmake_vendor_package" with any of the following names:
8.083 
8.083     ament_cmake_vendor_packageConfig.cmake
8.083     ament_cmake_vendor_package-config.cmake
8.083 
8.083   Add the installation prefix of "ament_cmake_vendor_package" to
8.083   CMAKE_PREFIX_PATH or set "ament_cmake_vendor_package_DIR" to a directory
8.083   containing one of the above files.  If "ament_cmake_vendor_package"
8.083   provides a separate development package or SDK, be sure it has been
8.083   installed.
8.083 
8.083 
8.083 ---
8.083 Failed   <<< intrinsic_pybind11_vendor [0.90s, exited with code 1]
8.089 --- stderr: flatbuffers_vendor
8.089 CMake Error at CMakeLists.txt:11 (find_package):
8.089   By not providing "Findament_cmake_vendor_package.cmake" in
8.089   CMAKE_MODULE_PATH this project has asked CMake to find a package
8.089   configuration file provided by "ament_cmake_vendor_package", but CMake did
8.089   not find one.
8.089 
8.089   Could not find a package configuration file provided by
8.089   "ament_cmake_vendor_package" with any of the following names:
8.089 
8.089     ament_cmake_vendor_packageConfig.cmake
8.089     ament_cmake_vendor_package-config.cmake
8.089 
8.089   Add the installation prefix of "ament_cmake_vendor_package" to
8.089   CMAKE_PREFIX_PATH or set "ament_cmake_vendor_package_DIR" to a directory
8.089   containing one of the above files.  If "ament_cmake_vendor_package"
8.089   provides a separate development package or SDK, be sure it has been
8.089   installed.
8.089 
8.089 
8.089 ---
8.089 Failed   <<< flatbuffers_vendor [0.89s, exited with code 1]
8.094 --- stderr: eigen_vendor
8.094 CMake Error at CMakeLists.txt:11 (find_package):
8.094   By not providing "Findament_cmake_vendor_package.cmake" in
8.094   CMAKE_MODULE_PATH this project has asked CMake to find a package
8.094   configuration file provided by "ament_cmake_vendor_package", but CMake did
8.094   not find one.
8.094 
8.094   Could not find a package configuration file provided by
8.094   "ament_cmake_vendor_package" with any of the following names:
8.094 
8.094     ament_cmake_vendor_packageConfig.cmake
8.094     ament_cmake_vendor_package-config.cmake
8.094 
8.094   Add the installation prefix of "ament_cmake_vendor_package" to
8.094   CMAKE_PREFIX_PATH or set "ament_cmake_vendor_package_DIR" to a directory
8.094   containing one of the above files.  If "ament_cmake_vendor_package"
8.094   provides a separate development package or SDK, be sure it has been
8.094   installed.
8.094 
8.094 
8.094 ---
8.094 Failed   <<< eigen_vendor [0.90s, exited with code 1]
```

This PR just readds it.