### PR TITLE
Fix unterminated string error in Dockerfile

### DIFF
--- a/resources/Dockerfile.service
+++ b/resources/Dockerfile.service
@@ -80,7 +80,7 @@ RUN cp \
         --expression '$iexport ENV ROS_HOME=/tmp' \
         /ros_entrypoint.sh \
     && sed --in-place \
-        --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=["tcp/zenoh-router.app-intrinsic-base:7447"]\'' \
+        --expression '$iexport ZENOH_CONFIG_OVERRIDE=\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base:7447\"]\'' \
         /ros_entrypoint.sh
 # TODO(Yadunund): Switch to ZENOH_CONFIG_OVERRIDE after the next jazzy sync.
 

--- a/resources/Dockerfile.service
+++ b/resources/Dockerfile.service
@@ -82,7 +82,6 @@ RUN cp \
     && sed --in-place \
         --expression '$iexport ZENOH_CONFIG_OVERRIDE=\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base:7447\"]\'' \
         /ros_entrypoint.sh
-# TODO(Yadunund): Switch to ZENOH_CONFIG_OVERRIDE after the next jazzy sync.
 
 # Build arguments are not substituted in the CMD command and hence we set environemnt variables
 # which can be substituted instead.

--- a/resources/Dockerfile.service
+++ b/resources/Dockerfile.service
@@ -80,7 +80,7 @@ RUN cp \
         --expression '$iexport ENV ROS_HOME=/tmp' \
         /ros_entrypoint.sh \
     && sed --in-place \
-        --expression '$iexport ZENOH_CONFIG_OVERRIDE=\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base:7447\"]\'' \
+        --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base:7447\"]\''' \
         /ros_entrypoint.sh
 
 # Build arguments are not substituted in the CMD command and hence we set environemnt variables


### PR DESCRIPTION
Building a ROS service actually resulted in an error because of a wrongly terminated string:

```
 > [stage-3 4/4] RUN cp         /opt/ros/overlay/install/share/${SERVICE_PACKAGE}/${SERVICE_NAME}/service_manifest.binarypb         /service_manifest.binarypb     && cp         /opt/ros/overlay/install/share/${SERVICE_PACKAGE}/${SERVICE_NAME}/default_config.binarypb         /default_config.binarypb     && cp         /opt/ros/overlay/install/share/${SERVICE_PACKAGE}/${SERVICE_NAME}/${SERVICE_NAME}_protos.desc         /parameter-descriptor-set.proto.bin     && sed --in-place         --expression '$isource "/opt/ros/overlay/install/setup.bash"'         /ros_entrypoint.sh     && sed --in-place         --expression '$iexport RMW_IMPLEMENTATION=rmw_zenoh_cpp'         /ros_entrypoint.sh     && sed --in-place         --expression '$iexport ENV ROS_HOME=/tmp'         /ros_entrypoint.sh     && sed --in-place         --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=["tcp/zenoh-router.app-intrinsic-base:7447"]\''         /ros_entrypoint.sh:
0.139 /bin/sh: 1: Syntax error: Unterminated quoted string
------

 1 warning found (use docker --debug to expand):
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 92)
Dockerfile.service:64
--------------------
  63 |     
  64 | >>> RUN cp \
  65 | >>>         /opt/ros/overlay/install/share/${SERVICE_PACKAGE}/${SERVICE_NAME}/service_manifest.binarypb \
  66 | >>>         /service_manifest.binarypb \
  67 | >>>     && cp \
  68 | >>>         /opt/ros/overlay/install/share/${SERVICE_PACKAGE}/${SERVICE_NAME}/default_config.binarypb \
  69 | >>>         /default_config.binarypb \
  70 | >>>     && cp \
  71 | >>>         /opt/ros/overlay/install/share/${SERVICE_PACKAGE}/${SERVICE_NAME}/${SERVICE_NAME}_protos.desc \
  72 | >>>         /parameter-descriptor-set.proto.bin \
  73 | >>>     && sed --in-place \
  74 | >>>         --expression '$isource "/opt/ros/overlay/install/setup.bash"' \
  75 | >>>         /ros_entrypoint.sh \
  76 | >>>     && sed --in-place \
  77 | >>>         --expression '$iexport RMW_IMPLEMENTATION=rmw_zenoh_cpp' \
  78 | >>>         /ros_entrypoint.sh \
  79 | >>>     && sed --in-place \
  80 | >>>         --expression '$iexport ENV ROS_HOME=/tmp' \
  81 | >>>         /ros_entrypoint.sh \
  82 | >>>     && sed --in-place \
  83 | >>>         --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=["tcp/zenoh-router.app-intrinsic-base:7447"]\'' \
  84 | >>>         /ros_entrypoint.sh
  85 |     # TODO(Yadunund): Switch to ZENOH_CONFIG_OVERRIDE after the next jazzy sync.
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c cp         /opt/ros/overlay/install/share/${SERVICE_PACKAGE}/${SERVICE_NAME}/service_manifest.binarypb         /service_manifest.binarypb     && cp         /opt/ros/overlay/install/share/${SERVICE_PACKAGE}/${SERVICE_NAME}/default_config.binarypb         /default_config.binarypb     && cp         /opt/ros/overlay/install/share/${SERVICE_PACKAGE}/${SERVICE_NAME}/${SERVICE_NAME}_protos.desc         /parameter-descriptor-set.proto.bin     && sed --in-place         --expression '$isource \"/opt/ros/overlay/install/setup.bash\"'         /ros_entrypoint.sh     && sed --in-place         --expression '$iexport RMW_IMPLEMENTATION=rmw_zenoh_cpp'         /ros_entrypoint.sh     && sed --in-place         --expression '$iexport ENV ROS_HOME=/tmp'         /ros_entrypoint.sh     && sed --in-place         --expression '$iexport ZENOH_CONFIG_OVERRIDE='\\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base:7447\"]\\''         /ros_entrypoint.sh" did not complete successfully: exit code: 2
```

You can reproduce locally without building the whole Docker image by just taking the sed expression in an empty bash and try to autocomplete by pressing TAB:

```
sed --in-place --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=["tcp/zenoh-router.app-intrinsic-base:7447"]\''
// TAB
bash: unexpected EOF while looking for matching `''
```

In the upstream PR that introduced the issue, #19, this was actually caught and fixed in another file in this commit https://github.com/intrinsic-ai/sdk-ros/pull/19/commits/5cd232e71e27f365ed00b811ed3b03dc7254cacd, but it missed the statement in this specific dockerfile.
You can try this the same way if building a docker file is too much work (it kinda is, it takes 20 minutes on my high powered machine!)

```
sed --in-place --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base:7447\"]\'''
// TAB
// No error
```