### PR TITLE
Fix deprecation warning to point to intrinsic_sdk_cmake

### DIFF
--- a/intrinsic_sdk/cmake/intrinsic_sdk-extras.cmake.in
+++ b/intrinsic_sdk/cmake/intrinsic_sdk-extras.cmake.in
@@ -1,1 +1,1 @@
-message(WARNING "This package ('intrinsic_sdk') is deprecated, use 'intrinsic_sdk_ros' instead.")
+message(WARNING "This package ('intrinsic_sdk') is deprecated, use 'intrinsic_sdk_cmake' instead.")


### PR DESCRIPTION
As noted in https://github.com/intrinsic-ai/insrc/pull/31433, users that were finding the `intrinsic_sdk` package or linking against the `intrinsic_sdk::intrinsic_sdk` target, should actually migrate to using `intrinsic_sdk_cmake` instead, since it's the one that provides the [CMake modules](https://github.com/intrinsic-ai/sdk-ros/tree/main/intrinsic_sdk_cmake/cmake), while `intrinsic_sdk_ros` [doesn't](https://github.com/intrinsic-ai/sdk-ros/tree/main/intrinsic_sdk_ros)