### PR TITLE
Add snapshot_interfaces package

### DIFF
--- a/snapshot_interfaces/CMakeLists.txt
+++ b/snapshot_interfaces/CMakeLists.txt
@@ -1,0 +1,57 @@
+###############################################################################
+# Copyright 2025 Intrinsic Innovation LLC
+#
+# You are hereby granted a non-exclusive, worldwide, royalty-free license to
+# use, copy, modify, and distribute this Intrinsic SDK in source code or binary
+# form for use in connection with the services and APIs provided by Intrinsic
+# Innovation LLC (“Intrinsic”).
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# If you use this Intrinsic SDK with any Intrinsic services, your use is
+# subject to the Intrinsic Platform Terms of Service
+# [https://intrinsic.ai/platform-terms].  If you create works that call
+# Intrinsic APIs, you must agree to the terms of service for those APIs
+# separately. This license does not grant you any special rights to use the
+# services.
+#
+# This copyright notice shall be included in all copies or substantial portions
+# of the software.
+###############################################################################
+
+cmake_minimum_required(VERSION 3.8)
+project(snapshot_interfaces)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/DiscoveredCamera.msg"
+  "msg/SensorInfo.msg"
+  "msg/ImageSnapshot.msg"
+  "msg/PointCloud2Snapshot.msg"
+  "msg/TemperatureSnapshot.msg"
+  "msg/ImuSnapshot.msg"
+  "srv/Discover.srv"
+  "srv/Describe.srv"
+  "srv/Snapshot.srv"
+  DEPENDENCIES
+  builtin_interfaces
+  geometry_msgs
+  sensor_msgs
+)
+
+ament_package()

--- a/snapshot_interfaces/LICENSE
+++ b/snapshot_interfaces/LICENSE
@@ -1,0 +1,21 @@
+# Copyright 2024 Intrinsic Innovation LLC
+
+Copyright 2024 Intrinsic Innovation LLC
+
+You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+copy, modify, and distribute this Intrinsic SDK in source code or binary form for use
+in connection with the services and APIs provided by Intrinsic Innovation LLC (“Intrinsic”).
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+If you use this Intrinsic SDK with any Intrinsic services, your use is subject to the Intrinsic
+Platform Terms of Service [https://intrinsic.ai/platform-terms].  If you create works that call
+Intrinsic APIs, you must agree to the terms of service for those APIs separately. This license
+does not grant you any special rights to use the services.
+
+This copyright notice shall be included in all copies or substantial portions of the software.

--- a/snapshot_interfaces/README.md
+++ b/snapshot_interfaces/README.md
@@ -1,0 +1,17 @@
+# Snapshot Interfaces
+
+This package provided interfaces for retrieving sensor data from cameras
+intermittently, as opposed to subscribing to a continuous data streams.
+
+It is intended to be provided either directly by a camera driver node,
+or by an "adapter node" that sits "in-between" a pre-existing streaming
+camera driver node and a client of this service.
+
+### Pre-existing work
+
+The `polled_camera` package uses a different approach, where image and
+`camera_info` topics are still used, but messages are only published on them
+when requested by a service call.  This package, in contrast, includes
+snapshots of all the requested topics in a single request-response transaction.
+This is convenient when there are many topics produced by a multi-sensor
+camera.

--- a/snapshot_interfaces/msg/DiscoveredCamera.msg
+++ b/snapshot_interfaces/msg/DiscoveredCamera.msg
@@ -1,0 +1,6 @@
+# The camera driver type.
+string driver_type
+
+# The id of the camera. This is typically something like the
+# device serial nubmer.
+string camera_id

--- a/snapshot_interfaces/msg/ImageSnapshot.msg
+++ b/snapshot_interfaces/msg/ImageSnapshot.msg
@@ -1,0 +1,5 @@
+string topic_name                  # Topic where the image was published. The
+                                   # CameraInfo message will be captured from
+                                   # its sibling topic, "../camera_info"
+sensor_msgs/Image image            # The Image message on topic_name
+sensor_msgs/CameraInfo camera_info # The message on the sibling camera_info

--- a/snapshot_interfaces/msg/ImuSnapshot.msg
+++ b/snapshot_interfaces/msg/ImuSnapshot.msg
@@ -1,0 +1,2 @@
+string topic_name   # Topic where this message was published
+sensor_msgs/Imu imu # The message captured on this topic

--- a/snapshot_interfaces/msg/PointCloud2Snapshot.msg
+++ b/snapshot_interfaces/msg/PointCloud2Snapshot.msg
@@ -1,0 +1,2 @@
+string topic_name                   # Topic where this message was published
+sensor_msgs/PointCloud2 point_cloud # The message captured on this topic

--- a/snapshot_interfaces/msg/SensorInfo.msg
+++ b/snapshot_interfaces/msg/SensorInfo.msg
@@ -1,0 +1,25 @@
+# The name of the sensor. This is typically something concise like
+# "color" or "infrared" or "depth"
+string sensor_name
+
+# The topic name where this sensor's data can be found. (This may
+# need to incorporate prefixes and suffixes around the sensor name.)
+string topic_name
+
+# The sensor type can be one of the following list. This list may grow
+# over time, as new sensors are included on devices using this message.
+uint32 sensor_type
+
+uint32 IMAGE=1
+uint32 POINT_CLOUD=2
+uint32 IMU=3
+uint32 TEMPERATURE=4
+
+# Each sensor within a camera typically has a static transform from
+# a "base link" of the camera to the sensor frame of interest, such
+# as the optical center of an image sensor, or the frame of an IMU.
+geometry_msgs/TransformStamped camera_t_sensor
+
+# For image sensors, it can be convenient to have a sample CameraInfo
+# before calling the Snapshot service.
+sensor_msgs/CameraInfo[<=1] info

--- a/snapshot_interfaces/msg/TemperatureSnapshot.msg
+++ b/snapshot_interfaces/msg/TemperatureSnapshot.msg
@@ -1,0 +1,2 @@
+string topic_name                   # Topic where this message was published
+sensor_msgs/Temperature temperature # The message captured on this topic

--- a/snapshot_interfaces/package.xml
+++ b/snapshot_interfaces/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>snapshot_interfaces</name>
+  <version>0.0.1</version>
+  <description>
+    This package provides interfaces to support polled operation of
+    ROS-compatible cameras, as opposed to streaming operation. This
+    can be useful for very high-resolution cameras whose output is
+    not always needed at maximum frame rate, and which would otherwise
+    consume large amounts of network bandwidth and CPU time if
+    streamed continually.
+  </description>
+  <author email="morganquigley@intrinsic.ai">Morgan Quigley</author>
+  <author email="timflichy@intrinsic.ai">Tim Flichy</author>
+  <author email="tullyfoote@intrinsic.ai">Tully Foote</author>
+  <maintainer email="morganquigley@intrinsic.ai">Morgan Quigley</maintainer>
+  <license>Intrinsic License</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/snapshot_interfaces/srv/Describe.srv
+++ b/snapshot_interfaces/srv/Describe.srv
@@ -1,0 +1,5 @@
+---
+SensorInfo[] sensors  # a list of sensors present in the device
+
+bool success          # true if the query completed successfully
+string error_message  # non-empty human-readable string if error

--- a/snapshot_interfaces/srv/Discover.srv
+++ b/snapshot_interfaces/srv/Discover.srv
@@ -1,0 +1,5 @@
+---
+DiscoveredCamera[]    cameras  # a list of discovered cameras
+
+bool success          # true if the query completed successfully
+string error_message  # non-empty human-readable string if error

--- a/snapshot_interfaces/srv/Snapshot.srv
+++ b/snapshot_interfaces/srv/Snapshot.srv
@@ -1,0 +1,25 @@
+# The intent of this service is to take a snapshot of a collection of sensor
+# topics published by a camera. This can be useful in applications where full
+# streaming of all of the sensor topics of the camera exceed the available
+# bandwidth, or are only periodically needed.  Because many cameras have
+# several sensors, there are lists for Image, PointCloud2, Imu, and Temperature
+# topics. A call to this service can capture a variable number of each of those
+# topic types.
+
+uint32 capture_policy                # Sets waiting behavior, as per enums:
+uint32 WAIT_FOR_NEXT=0               # Default: wait for the next message
+uint32 MOST_RECENT=1                 # Retrieve the most-recent message
+uint32 WAIT_FOR_TRIGGER_TIME=2       # Wait until trigger_time
+builtin_interfaces/Time trigger_time # Only used by WAIT_FOR_TRIGGER_TIME
+
+builtin_interfaces/Duration timeout  # If nonzero, the maximum time to wait
+
+---
+
+ImageSnapshot[] images               # Captured images and matching CameraInfos
+PointCloud2Snapshot[] point_clouds   # Captured point clouds
+ImuSnapshot[] imus                   # Captured IMUs
+TemperatureSnapshot[] temperatures   # Captured temperatures
+
+bool success                         # true if all topics were captured
+string error_message                 # human-readable error string


### PR DESCRIPTION
Add the `snapshot_interfaces` package, which defines interfaces to allow "snapshot-style" interaction with existing ROS camera drivers.