### PR TITLE
Update the zenoh-router in-cluster DNS name

### DIFF
--- a/resources/Dockerfile.service
+++ b/resources/Dockerfile.service
@@ -80,7 +80,7 @@ RUN cp \
         --expression '$iexport ENV ROS_HOME=/tmp' \
         /ros_entrypoint.sh \
     && sed --in-place \
-        --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base:7447\"]\''' \
+        --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base.svc.cluster.local:7447\"]\''' \
         /ros_entrypoint.sh
 
 # Build arguments are not substituted in the CMD command and hence we set environemnt variables


### PR DESCRIPTION
Update the `zenoh-router` DNS name so that it routes correctly in Kubernetes.