### PR TITLE
Update zenoh locator in intrinsic_sdk_cmake_base

### DIFF
--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_base.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_base.Dockerfile
@@ -32,7 +32,7 @@ RUN set -x \
         --expression '$iexport ENV ROS_HOME=/tmp' \
         /ros_entrypoint.sh \
     && sed --in-place \
-        --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base:7447\"]\''' \
+        --expression '$iexport ZENOH_CONFIG_OVERRIDE='\'connect/endpoints=[\"tcp/zenoh-router.app-intrinsic-base.svc.cluster.local:7447\"]\''' \
         /ros_entrypoint.sh
 
 CMD ["bash"]


### PR DESCRIPTION
Same as was needed for `Dockerfile.service` in #52  , just propagating updates in the Kubernetes config.