### PR TITLE
Ensure clang is being used to build ortools

### DIFF
--- a/ortools_vendor/CMakeLists.txt
+++ b/ortools_vendor/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.10)
 project(ortools_vendor CXX)
 
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  message(FATAL_ERROR
+  "Clang is required. Detected: ${CMAKE_CXX_COMPILER_ID}. "
+  "'sudo apt install clang-19' and invoke colcon with --cmake-args as shown in "
+  "https://github.com/intrinsic-ai/sdk-ros?tab=readme-ov-file#getting-started")
+endif()
+
 # Default to C++20
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
It seems that `clang-19` is required to build the current version of `ortools_vendor` and its dependencies. Unclear exactly why; perhaps it's some C++17 vs C++20 syntax that is handled slightly differently? Anyway, for now at least, this PR adds a CMake `FATAL_ERROR` if a different compiler is being used, so that it's easier and faster to realize what is happening and how to work around it.