### PR TITLE
build inbuild

### DIFF
--- a/intrinsic_sdk_cmake/cmake/sdk_tools.cmake
+++ b/intrinsic_sdk_cmake/cmake/sdk_tools.cmake
@@ -107,3 +107,37 @@ set_target_properties(skill_service_generator_import
 )
 add_dependencies(skill_service_generator_import skill_service_generator)
 add_executable(${PROJECT_NAME}::skill_service_generator ALIAS skill_service_generator_import)
+
+# Build inbuild
+add_custom_command(
+  OUTPUT "${sdk_bins_DIR}/inbuild"
+  WORKING_DIRECTORY "${intrinsic_sdk_SOURCE_DIR}/intrinsic"
+  COMMAND
+    ${bazelisk_vendor_EXECUTABLE}
+      --nohome_rc
+      --quiet
+      run
+        --experimental_convenience_symlinks=ignore
+        --run_under=cp
+        //intrinsic/tools/inbuild
+        "${sdk_bins_DIR}/inbuild"
+  VERBATIM
+)
+add_custom_target(inbuild
+  ALL
+  DEPENDS
+    "${sdk_bins_DIR}/inbuild"
+)
+install(
+  PROGRAMS
+    "${sdk_bins_DIR}/inbuild"
+  DESTINATION bin
+)
+# Create an imported executable and namespace it to imitate find_package()
+add_executable(inbuild_import IMPORTED)
+set_target_properties(inbuild_import
+  PROPERTIES
+    IMPORTED_LOCATION "${sdk_bins_DIR}/inbuild"
+)
+add_dependencies(inbuild_import inbuild)
+add_executable(${PROJECT_NAME}::inbuild ALIAS inbuild_import)


### PR DESCRIPTION
Build `inbuild` as part of `intrinsic_sdk_cmake`, so that it can be used for skill bundling (and other things in the future).