### PR TITLE
Fix hash map check to prevent fetching duplicate meshes

### DIFF
--- a/flowstate_ros_bridge/src/bridges/world_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.cpp
@@ -191,7 +191,7 @@ absl::Status WorldBridge::Data::SendObjectVisualizationMessages(
               "gltf/%s_%s.glb",
               geometry.geometry_storage_refs().geometry_ref().substr(9),
               geometry.geometry_storage_refs().renderable_ref().substr(9));
-          if (renderables_.contains(gltf_path)) {
+          if (renderables_.contains(std::string("/") + gltf_path)) {
             continue;
           }
 
@@ -265,7 +265,10 @@ absl::Status WorldBridge::Data::SendObjectVisualizationMessages(
   }
   LOG(INFO) << "Total gltf size: " << total_gltf_size << " bytes";
 
-  workcell_markers_pub_->publish(array_msg);
+  if (!array_msg.empty()){
+    workcell_markers_pub_->publish(array_msg);
+  }
+  
   return absl::OkStatus();
 }
 

--- a/flowstate_ros_bridge/src/bridges/world_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.cpp
@@ -265,10 +265,10 @@ absl::Status WorldBridge::Data::SendObjectVisualizationMessages(
   }
   LOG(INFO) << "Total gltf size: " << total_gltf_size << " bytes";
 
-  if (!array_msg.empty()){
+  if (!array_msg.markers.empty()){
     workcell_markers_pub_->publish(array_msg);
   }
-  
+
   return absl::OkStatus();
 }
 


### PR DESCRIPTION
Hi, I have found that the `world_bridge` will still fetch duplicate meshes because of a mismatched key check, so I have made the following fixes in this PR:
1. Fix check for existing mesh file key so as to avoid fetching duplicate meshes
2. Added check to avoid publishing empty array messages, which is can result from how we need to check for new scene objects using the Zenoh pubsub "/tf" topic