### PR TITLE
remove unused gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "intrinsic_sdk/sdk"]
-	path = intrinsic_sdk/sdk
-	url = https://github.com/intrinsic-dev/sdk


### PR DESCRIPTION
`intrinsic_sdk` is now downloaded and built as part of the `intrinsic_sdk_cmake` build, so the `.gitmodules` file is no longer needed.